### PR TITLE
Replace Twitter media URIs with display links only

### DIFF
--- a/earl.pl
+++ b/earl.pl
@@ -193,10 +193,10 @@ sub get_tweet {
     }
 
     foreach my $entity (@{$entities->{media}}) {
-      if (my @indices = @{$entity->{indices}} and my $ent_url = $entity->{display_url}) {
+      if (my @indices = @{$entity->{indices}}) {
         # Second index is next character after URL
         @text_array[$indices[0]..($indices[1] - 1)] = @replace_array;
-        $text_array[$indices[0]] = $ent_url;
+        $text_array[$indices[0]] = "*IMG*";
       }
     }
 


### PR DESCRIPTION
Purpose of full links is to be clickable, but there is already a link to the tweet in question which works.  Possibly this can be replaced by a constant instead? Which saves premium text space.

Also, apparently adding things to strings causes indices to change, who knew!
