### PR TITLE
Replace grouped whitespace by single

### DIFF
--- a/earl.pl
+++ b/earl.pl
@@ -218,6 +218,7 @@ sub said {
     if ( $url and $reply ) {
 
       # Sanitise the reply to only include printable chars
+      $reply =~ s/\s+/ /g;
       $reply =~ s/[^[:print:]]//g;
 
       # Strip unicode of death for Core Text on Macs


### PR DESCRIPTION
When newlines are used to separate text they mess up formatting if removed
