### PR TITLE
Despite claims to the contrary, Twitter seems to be escaping ampersands ...

### DIFF
--- a/earl.pl
+++ b/earl.pl
@@ -182,7 +182,7 @@ sub get_tweet {
   my $response = $ua->get( $url, 'Authorization' => $auth );
   return unless $response->is_success;
 
-  my $json = decode_json( $response->decoded_content );
+  my $json = decode_json( decode_entities( $response->decoded_content ) );
   my $text = $json->{text};
 
   if (my $entities = $json->{entities}) {


### PR DESCRIPTION
...in the JSON response. And <> will need to be converted anyway

Claims to the contrary:
- http://code.google.com/p/twitter-api/issues/detail?id=1695

Example of HTML ampersand: https://twitter.com/rootlabs/status/453945939367956480
